### PR TITLE
Remove build-signed script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "clean": "./scripts/clean.sh",
     "compile": "./scripts/compile.sh",
     "build": "./scripts/build.sh",
-    "build-signed": "./scripts/build-signed.sh",
     "reindex-prices": "./scripts/reindex-prices.sh"
   },
   "repository": {

--- a/scripts/build-signed.sh
+++ b/scripts/build-signed.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -xeuo pipefail
-
-./scripts/compile.sh
-(
-  cd ./dist
-  web-ext sign --channel listed
-)


### PR DESCRIPTION
The build-signed script only submitted to the Mozilla store and it
didn't do the right thing for listed extensions.