### PR TITLE
web-ext --start-url=...

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,13 @@
 ## Building
 
 1. Pull the repository
+
    ```bash
    git clone git@github.com:deref/deref-browser-extensions.git && cd deref-browser-extensions
    ```
 
 2. Install the dependencies
+
    ```bash
    npm install
    ```
@@ -16,6 +18,10 @@
    ```bash
    npm run build
    ```
+
+## Configuration
+
+Optional: Configure and login to the AWS CLI.
 
 ## Starting the dev environment
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -6,7 +6,15 @@ set -xeuo pipefail
 # shellcheck disable=SC2064
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
-(cd dist && web-ext run --verbose) &
+# Use local AWS CLI config to find a convenient login url.
+account_id="$(aws sts get-caller-identity --query 'Account' --output text)"
+if [[ -z "$account_id" ]]; then
+  start_url="https://signin.aws.amazon.com/console"
+else
+  start_url="https://${account_id}.signin.aws.amazon.com/console"
+fi
+
+(cd dist && web-ext run --verbose "--start-url=$start_url") &
 esbuild --bundle --target=firefox86,chrome88 --outdir='./dist/src' ./*.ts ./*.tsx --watch &
 
 wait


### PR DESCRIPTION
Improve the dev experience by setting `--start-url=` to the user's configured AWS account when launching the browser extension.