### PR TITLE
Styling fixes & re-enable button and panel

### DIFF
--- a/components/DerefButton.tsx
+++ b/components/DerefButton.tsx
@@ -7,10 +7,10 @@ import DerefLogoLong from '~/components/svg/DerefLogoLong';
 
 export default function DerefButton(props: RouteComponentProps) {
   return (
-    <div className="h-full flex items-center">
+    <div className="h-full w-full flex items-center justify-center">
       <div
         className={classNames(
-          'h-full px-4 fill-current flex items-center select-none cursor-pointer font-medium',
+          'h-full w-full px-4 fill-current flex items-center select-none cursor-pointer font-medium',
           {
             'border-gray-600 bg-gray-900 hover:bg-gray-800 border-l text-white pb-px': !props
               .derefContext.panelState.visible,

--- a/components/PriceBar.tsx
+++ b/components/PriceBar.tsx
@@ -32,7 +32,7 @@ export default function PriceBar(props: Props) {
   return (
     <div
       className={classNames(
-        'rounded border border-gray-300 shadow flex m-1 overflow-hidden',
+        'rounded border border-gray-300 bg-white shadow flex m-1 overflow-hidden',
         {
           'flex-col': props.vertical,
         },

--- a/components/note/NoteTextArea.tsx
+++ b/components/note/NoteTextArea.tsx
@@ -75,7 +75,7 @@ export default function NoteTextArea(props: Props) {
       try {
         await props.onSave({ id: props.note?.id, body });
         setSaveState('saved');
-      } catch (e: unknown) {
+      } catch (e) {
         setSaveState('error');
       }
     },
@@ -97,13 +97,13 @@ export default function NoteTextArea(props: Props) {
         <textarea
           ref={textAreaRef}
           value={body}
-          onChange={(e) => setBody(e.target.value)}
-          className="w-full h-full"
+          onChange={e => setBody(e.target.value)}
+          className="w-full h-full outline-none resize-none"
           placeholder="Add a note..."
           autoFocus={props.autoFocus}
           onFocus={
             props.autoFocus
-              ? (e) => {
+              ? e => {
                   const value = e.target.value;
                   e.target.value = '';
                   e.target.value = value;

--- a/components/routes.tsx
+++ b/components/routes.tsx
@@ -45,11 +45,11 @@ const routes = {
   button: createRoute({
     component: DerefButton,
     style: context => ({
-      height: '40px',
+      height: '41px',
       width: '120px',
       marginTop: '-2px',
       marginBottom: '-3px',
-      marginRight: '-24px',
+      marginRight: '-22px',
     }),
   }),
   priceBar: createRoute({

--- a/components/routes.tsx
+++ b/components/routes.tsx
@@ -45,8 +45,11 @@ const routes = {
   button: createRoute({
     component: DerefButton,
     style: context => ({
-      height: '36px',
-      width: '128px',
+      height: '40px',
+      width: '120px',
+      marginTop: '-2px',
+      marginBottom: '-3px',
+      marginRight: '-24px',
     }),
   }),
   priceBar: createRoute({

--- a/page-handlers/deref-button.ts
+++ b/page-handlers/deref-button.ts
@@ -9,7 +9,7 @@ export const derefButton: PageHandler = {
   conditions: [
     isNotIframe,
     urlMatchesRegex(/.*console.aws.amazon.com/),
-    () => false, // Temporarily disable the button.
+    // () => false, Temporarily disable the button.
   ],
   async handler(context) {
     void makeDerefExtensionContainer({

--- a/page-handlers/deref-panel.ts
+++ b/page-handlers/deref-panel.ts
@@ -9,7 +9,7 @@ export const derefPanel: PageHandler = {
   conditions: [
     isNotIframe,
     urlMatchesRegex(/.*console.aws.amazon.com/),
-    () => false, // Temporarily disable the panel.
+    // () => false, Temporarily disable the panel.
   ],
   async handler(context) {
     void makeDerefExtensionContainer({


### PR DESCRIPTION
This improves and fixes a few things:

- Add white background to Pricing Bar so that it shows up properly in the AWS console itself
- Remove outline and resize from the NoteTextArea component
- Re-enable button and panel in the extension

![image](https://user-images.githubusercontent.com/51100181/117048335-db7d3600-ace0-11eb-9c02-eb2a8f394533.png)
